### PR TITLE
Render "liked by" names through get_username_string()

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -124,7 +124,10 @@ class main_listener implements EventSubscriberInterface
 		$result = $this->db->sql_query($sql);
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$this->post_likers[(int) $row['post_id']][(int) $row['user_id']] = $row['username'];
+			// Render through get_username_string() rather than the raw username so
+			// username-rewriting extensions (e.g. guest pseudonyms) and phpBB's own
+			// handling of guests/deleted users apply to the "liked by" list too.
+			$this->post_likers[(int) $row['post_id']][(int) $row['user_id']] = get_username_string('username', (int) $row['user_id'], $row['username']);
 		}
 		$this->db->sql_freeresult($result);
 


### PR DESCRIPTION
The "liked by" list is built from the raw `u.username`, which bypasses phpBB's username rendering.

Routing each liker through `get_username_string('username', …)` means:

- username-rewriting extensions (e.g. guest-pseudonyms) apply to the "liked by" tooltip like they do everywhere else on the board;
- guests and deleted users render the way phpBB renders them elsewhere.

Output is unchanged on a normal forum — the `username` mode returns plain text, exactly like the raw column, so the comma-separated list looks identical. One-line change in `prefetch_likes()`.
